### PR TITLE
fix(1.3.1): defines field as {} if external value is undefined

### DIFF
--- a/app-field-reference-multisite/package-lock.json
+++ b/app-field-reference-multisite/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app-field-reference-multisite",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "app-field-reference-multisite",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "@contentful/app-sdk": "4.12.0",
         "@contentful/f36-components": "4.15.0",

--- a/app-field-reference-multisite/package.json
+++ b/app-field-reference-multisite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-field-reference-multisite",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "dependencies": {
     "@contentful/app-sdk": "4.12.0",

--- a/app-field-reference-multisite/src/locations/Field.tsx
+++ b/app-field-reference-multisite/src/locations/Field.tsx
@@ -22,6 +22,9 @@ const Field = () => {
   let detachSiteChangeHandler: Function | null = null
 
   const [field, setField] = useState<ReferenceMultiSite>(sdk.field.getValue() ?? {})
+  console.log(sdk.field.getValue())
+  console.log('actual field', field)
+  console.log('sites', sites)
 
   const updateField = (newField: ReferenceMultiSite) => {
     sdk.field.setValue(newField)
@@ -39,7 +42,7 @@ const Field = () => {
   }
 
   const onExternalChange = (externalValue: ReferenceMultiSite) => {
-    setField(externalValue)
+    setField(externalValue ?? {})
   }
 
   const siteChangeHandler = (newSites: Array<string> | undefined) => {


### PR DESCRIPTION
# Fix
* Field was being set as undefined in onExternalChange function. A fallback {} value was defined. 